### PR TITLE
修复CLI入口判断逻辑: issues/19

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,6 @@ export const program = createProgram();
 
 // 仅在作为主模块运行时执行 parse，防止测试文件 import 时意外触发
 import url from "node:url";
-if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+if (import.meta.url && import.meta.url.startsWith(url.pathToFileURL(process.argv[1]).href)) {
     program.parse(process.argv);
 }


### PR DESCRIPTION
fix(cli): 修复CLI入口判断逻辑

当import.meta.url存在且以正确的文件路径开头时才执行程序解析，
避免在某些环境下因URL格式不匹配导致的意外行为
```