### PR TITLE
添加微信应用ID和密钥配置支持, server 支持多个公众号  issues/17

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,3 @@
+# 必须使用 LF Line Sequence
+WECHAT_APP_ID=123456
+WECHAT_APP_SECRET=abcdef

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint . --fix",
     "test:bin": "pnpm build && node ./dist/cli.js render -f tests/publish.md -c tests/manhua.css --no-mac-style",
     "test:realPublish": "pnpm build && node --env-file=.env.test ./dist/cli.js publish -f tests/publish.md -t phycat",
-    "test:serverPublish": "pnpm build && node ./dist/cli.js publish -f tests/publish.md -c tests/manhua.css --no-mac-style --server http://localhost:3000",
+    "test:serverPublish": "pnpm build && node --env-file=.env.test ./dist/cli.js publish -f tests/publish.md -c tests/manhua.css --no-mac-style --server http://localhost:3000",
     "test:serve": "pnpm build && node --env-file=.env.test ./dist/cli.js serve"
   },
   "packageManager": "pnpm@10.7.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,10 +46,18 @@ export function createProgram(version: string = pkg.version): Command {
     addCommonOptions(pubCmd)
         .option("--server <url>", "Server URL to publish through (e.g. https://api.yourdomain.com)")
         .option("--api-key <apiKey>", "API key for the remote server")
+        .option("--app-id [id]", "WeChat ID to publish to</id>, if not specified, will use the env variable WECHAT_APP_ID")
+        .option("--app-secret [secret]", "WeChat Secret to publish to</secret>, if not specified, will use the env variable WECHAT_APP_SECRET")
         .action(async (inputContent: string | undefined, options: ClientPublishOptions) => {
             await runCommandWrapper(async () => {
                 // 如果传入了 --server，则走客户端（远程）模式
                 if (options.server) {
+                    if(!options.appId){
+                        options.appId = process.env.WECHAT_APP_ID;
+                    }
+                    if(!options.appSecret){
+                        options.appSecret = process.env.WECHAT_APP_SECRET;
+                    }
                     options.clientVersion = version; // 将 CLI 版本传递给服务器，便于调试和兼容性处理
                     const mediaId = await renderAndPublishToServer(inputContent, options, getInputContent);
                     console.log(`发布成功，Media ID: ${mediaId}`);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -13,6 +13,8 @@ export interface ServeOptions {
 }
 
 interface RenderRequest {
+    appId?: string;
+    appSecret?: string;
     fileId: string;
     theme?: string;
     highlight?: string;
@@ -145,6 +147,9 @@ export async function serveCommand(options: ServeOptions) {
             cover: gzhContent.cover,
             author: gzhContent.author,
             source_url: gzhContent.source_url,
+        },{
+            appId: body.appId,
+            appSecret: body.appSecret
         });
 
         if (data.media_id) {


### PR DESCRIPTION
feat(cli): 添加微信应用ID和密钥配置支持

添加了 --app-id 和 --app-secret 命令行选项用于微信发布功能，
支持通过环境变量 WECHAT_APP_ID 和 WECHAT_APP_SECRET 配置，
新增 .example.env 文件提供配置示例，
更新测试命令以支持环境变量文件加载
```