### PR TITLE
refactor(cli): 使用import.meta.main替代URL比较

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,6 @@ export const program = createProgram();
 
 // 仅在作为主模块运行时执行 parse，防止测试文件 import 时意外触发
 import url from "node:url";
-if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+if (import.meta.main) {
     program.parse(process.argv);
 }


### PR DESCRIPTION
refactor(cli): 使用import.meta.main替代URL比较

- 将条件判断从复杂的URL比较改为更简洁的import.meta.main
- 提高代码可读性和维护性
- 避免了引入node:url模块的需求
```