### PR TITLE
feat(publish): 添加代理功能支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ wenyan <command> [options]
 
 | 命令      | 说明        |
 | ------- | --------- |
-| [publish](docs/publish.md) | 发布文章      |
+| [publish](docs/publish.md) | 发布文章（支持 `--proxy` 代理）      |
 | render  | 渲染 HTML   |
 | [theme](docs/theme.md)   | 管理主题      |
 | [serve](docs/server.md)   | 启动 Server |

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -158,6 +158,7 @@ wenyan publish \
 | --no-footnote  | -  | 禁用脚注转换             | 否  | 启用              |
 | --server       | -  | Wenyan Server 地址   | 否  | -               |
 | --api-key      | -  | Server API Key     | 否² | -               |
+| --proxy        | -  | 代理服务器地址           | 否  | -               |
 | --help         | -  | 查看帮助               | 否  | -               |
 
 说明：
@@ -169,6 +170,46 @@ wenyan publish \
 * 直接传入 Markdown 内容
 
 ² 仅在指定 `--server` 时生效。
+
+### 代理配置说明
+
+`--proxy` 参数支持以下格式的代理服务器：
+
+- **HTTP 代理**: `http://127.0.0.1:7890`
+- **HTTPS 代理**: `https://127.0.0.1:7890`
+- **SOCKS5 代理**: `socks5://127.0.0.1:1080`
+- **SOCKS4 代理**: `socks4://127.0.0.1:1080`
+
+**使用示例：**
+
+```bash
+# 使用 HTTP 代理
+wenyan publish -f article.md --proxy http://127.0.0.1:7890
+
+# 使用 SOCKS5 代理
+wenyan publish -f article.md --proxy socks5://127.0.0.1:1080
+```
+
+**或者使用环境变量（推荐）：**
+
+```bash
+# Windows PowerShell
+$env:HTTP_PROXY="http://127.0.0.1:7890"
+wenyan publish -f article.md
+
+# Linux/Mac
+export HTTP_PROXY=http://127.0.0.1:7890
+wenyan publish -f article.md
+
+# 使用 SOCKS5 代理
+export ALL_PROXY=socks5://127.0.0.1:1080
+wenyan publish -f article.md
+```
+
+> [!NOTE]
+> 
+> 代理配置会应用于所有微信 API 调用和图片上传操作。
+> 如果使用认证代理，格式为：`http://username:password@proxy-server:port`
 
 ## 示例
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ export function createProgram(version: string = pkg.version): Command {
     addCommonOptions(pubCmd)
         .option("--server <url>", "Server URL to publish through (e.g. https://api.yourdomain.com)")
         .option("--api-key <apiKey>", "API key for the remote server")
+        .option("--proxy <url>", "Proxy URL to use for requests</url>, ex:")
         .action(async (inputContent: string | undefined, options: ClientPublishOptions) => {
             await runCommandWrapper(async () => {
                 // 如果传入了 --server，则走客户端（远程）模式


### PR DESCRIPTION
- 在 publish 命令中新增 --proxy 选项用于配置代理服务器
- 支持 HTTP、HTTPS、SOCKS5、SOCKS4 等多种代理协议
- 更新文档说明代理配置方法和使用示例
- 代理配置将应用于所有微信 API 调用和图片上传操作
- 支持通过命令行参数或环境变量设置代理