### PR TITLE
feat(publish): 添加代理配置功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wenyan <command> [options]
 
 | 命令      | 说明        |
 | ------- | --------- |
-| [publish](docs/publish.md) | 发布文章（支持 `--proxy` 代理）      |
+| [publish](docs/publish.md) | 发布文章      |
 | render  | 渲染 HTML   |
 | [theme](docs/theme.md)   | 管理主题      |
 | [credential](docs/credential.md)   | 配置公众号凭据 |
@@ -84,10 +84,14 @@ wenyan <command> [options]
 
 > [!IMPORTANT]
 >
-> 请确保运行文颜的机器已配置如下环境变量，否则上传接口将调用失败。
+> 请确保运行文颜的机器已配置如下环境变量，否则上传接口[`wenyan publish`]将调用失败。
 
 -   `WECHAT_APP_ID`
 -   `WECHAT_APP_SECRET`
+
+> [!NOTE]
+>
+> 你可以通过`--env-file=.env`的方式配置环境变量。
 
 ### 微信公众号 IP 白名单
 
@@ -96,6 +100,10 @@ wenyan <command> [options]
 > 请确保运行文颜的机器 IP 已加入微信公众号后台的 IP 白名单，否则上传接口将调用失败。
 
 配置说明文档：[https://yuzhi.tech/docs/wenyan/upload](https://yuzhi.tech/docs/wenyan/upload)
+
+> [!NOTE]
+>
+> 你可以通过`server`模式或者[添加代理](docs/publish.md)两种方式解决 IP 频繁变动的问题。
 
 ### 文章格式
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wenyan <command> [options]
 
 | 命令      | 说明        |
 | ------- | --------- |
-| [publish](docs/publish.md) | 发布文章      |
+| [publish](docs/publish.md) | 发布文章（支持 `--proxy` 代理）      |
 | render  | 渲染 HTML   |
 | [theme](docs/theme.md)   | 管理主题      |
 | [credential](docs/credential.md)   | 配置公众号凭据 |

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -159,6 +159,7 @@ wenyan publish \
 | --app-id       | -  | 需要发布的公众号 AppId   | 否  | -               |
 | --server       | -  | Wenyan Server 地址   | 否  | -               |
 | --api-key      | -  | Server API Key     | 否² | -               |
+| --proxy        | -  | 代理服务器地址           | 否  | -               |
 | --help         | -  | 查看帮助               | 否  | -               |
 
 说明：
@@ -170,6 +171,46 @@ wenyan publish \
 * 直接传入 Markdown 内容
 
 ² 仅在指定 `--server` 时生效。
+
+### 代理配置说明
+
+`--proxy` 参数支持以下格式的代理服务器：
+
+- **HTTP 代理**: `http://127.0.0.1:7890`
+- **HTTPS 代理**: `https://127.0.0.1:7890`
+- **SOCKS5 代理**: `socks5://127.0.0.1:1080`
+- **SOCKS4 代理**: `socks4://127.0.0.1:1080`
+
+**使用示例：**
+
+```bash
+# 使用 HTTP 代理
+wenyan publish -f article.md --proxy http://127.0.0.1:7890
+
+# 使用 SOCKS5 代理
+wenyan publish -f article.md --proxy socks5://127.0.0.1:1080
+```
+
+**或者使用环境变量（推荐）：**
+
+```bash
+# Windows PowerShell
+$env:HTTP_PROXY="http://127.0.0.1:7890"
+wenyan publish -f article.md
+
+# Linux/Mac
+export HTTP_PROXY=http://127.0.0.1:7890
+wenyan publish -f article.md
+
+# 使用 SOCKS5 代理
+export ALL_PROXY=socks5://127.0.0.1:1080
+wenyan publish -f article.md
+```
+
+> [!NOTE]
+> 
+> 代理配置会应用于所有微信 API 调用和图片上传操作。
+> 如果使用认证代理，格式为：`http://username:password@proxy-server:port`
 
 ## 示例
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -160,6 +160,7 @@ wenyan publish \
 | --server       | -  | Wenyan Server 地址   | 否  | -               |
 | --api-key      | -  | Server API Key     | 否² | -               |
 | --proxy        | -  | 代理服务器地址           | 否  | -               |
+| --env-file     | -  | 指定环境变量配置文件（如 .env.local）           | 否  | -               |
 | --help         | -  | 查看帮助               | 否  | -               |
 
 说明：
@@ -173,44 +174,39 @@ wenyan publish \
 ² 仅在指定 `--server` 时生效。
 
 ### 代理配置说明
+`--proxy` 支持 HTTP/HTTPS/SOCKS4/SOCKS5 代理，也可通过环境变量配置，代理会作用于所有微信 API 调用与图片上传。
 
-`--proxy` 参数支持以下格式的代理服务器：
-
-- **HTTP 代理**: `http://127.0.0.1:7890`
-- **HTTPS 代理**: `https://127.0.0.1:7890`
-- **SOCKS5 代理**: `socks5://127.0.0.1:1080`
-- **SOCKS4 代理**: `socks4://127.0.0.1:1080`
-
-**使用示例：**
-
+**常用格式：**
 ```bash
-# 使用 HTTP 代理
-wenyan publish -f article.md --proxy http://127.0.0.1:7890
-
-# 使用 SOCKS5 代理
-wenyan publish -f article.md --proxy socks5://127.0.0.1:1080
+http://127.0.0.1:7890
+https://127.0.0.1:7890
+socks4://127.0.0.1:1080
+socks5://127.0.0.1:1080
 ```
 
-**或者使用环境变量（推荐）：**
-
+**命令行使用：**
 ```bash
-# Windows PowerShell
-$env:HTTP_PROXY="http://127.0.0.1:7890"
-wenyan publish -f article.md
+wenyan publish -f article.md --proxy http://127.0.0.1:7890
+```
 
+**环境变量（推荐）：**
+```bash
 # Linux/Mac
 export HTTP_PROXY=http://127.0.0.1:7890
-wenyan publish -f article.md
-
-# 使用 SOCKS5 代理
 export ALL_PROXY=socks5://127.0.0.1:1080
-wenyan publish -f article.md
+
+# Windows PowerShell
+$env:HTTP_PROXY="http://127.0.0.1:7890"
 ```
 
 > [!NOTE]
-> 
-> 代理配置会应用于所有微信 API 调用和图片上传操作。
-> 如果使用认证代理，格式为：`http://username:password@proxy-server:port`
+>
+> `--env-file` 可指定自定义环境变量文件。
+
+**带认证代理：**
+```
+http://username:password@proxy-server:port
+```
 
 ## 示例
 
@@ -286,12 +282,16 @@ wenyan publish \
 
 ### 发布失败：invalid appid or secret
 
-请检查环境变量：
+请检查环境变量中是否存在如下配置：
 
 ```bash
 WECHAT_APP_ID
 WECHAT_APP_SECRET
 ```
+
+> [!NOTE]
+>
+> `--env-file` 可指定自定义环境变量文件。
 
 如果配置了多公众号发布，使用`wenyan credential -l`命令，查看凭据中是否正确配置了`AppId`和`AppSecret`。
 

--- a/package.json
+++ b/package.json
@@ -40,22 +40,22 @@
     "lint": "eslint . --fix",
     "cli": "tsx ./src/cli.ts",
     "test:bin": "pnpm build && node ./dist/cli.js render -f tests/publish.md -c tests/manhua.css --no-mac-style",
-    "test:realPublish": "pnpm build && node --env-file=.env.test ./dist/cli.js publish -f tests/publish.md -t phycat",
+    "test:realPublish": "pnpm build && node ./dist/cli.js publish -f tests/publish.md -t phycat --env-file=.env.test",
     "test:serverPublish": "pnpm build && node ./dist/cli.js publish -f tests/publish.md -c tests/manhua.css --no-mac-style --server http://localhost:3000",
-    "test:serve": "pnpm build && node --env-file=.env.test ./dist/cli.js serve"
+    "test:serve": "pnpm build && node ./dist/cli.js serve --env-file=.env.test"
   },
   "packageManager": "pnpm@10.7.1",
   "dependencies": {
     "@inquirer/input": "^5.0.11",
     "@inquirer/password": "^5.0.11",
     "@wenyan-md/core": "^3.0.4",
-    "dotenv": "^17.4.1",
     "commander": "^14.0.0",
     "express": "^5.2.1",
     "form-data-encoder": "^4.1.0",
     "formdata-node": "^6.0.3",
     "jsdom": "^27.4.0",
-    "multer": "^2.1.0"
+    "multer": "^2.1.0",
+    "undici": "^8.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@inquirer/input": "^5.0.11",
     "@inquirer/password": "^5.0.11",
     "@wenyan-md/core": "^3.0.4",
+    "dotenv": "^17.4.1",
     "commander": "^14.0.0",
     "express": "^5.2.1",
     "form-data-encoder": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       multer:
         specifier: ^2.1.0
         version: 2.1.0
+      undici:
+        specifier: ^8.0.2
+        version: 8.1.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1229,6 +1232,10 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  undici@8.1.0:
+    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2455,6 +2462,8 @@ snapshots:
   typescript@5.9.2: {}
 
   undici-types@7.10.0: {}
+
+  undici@8.1.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,13 @@ import { getInputContent } from "./utils.js";
 import path from "node:path";
 import input from "@inquirer/input";
 import password from "@inquirer/password";
-import dotenv from "dotenv";
+import { loadEnvFile } from "node:process";
+
+interface CLIPublishOptions extends ClientPublishOptions {
+    proxy?: string;
+    envFile?: string;
+}
+
 export function createProgram(version: string = pkg.version): Command {
     const program = new Command();
 
@@ -52,16 +58,17 @@ export function createProgram(version: string = pkg.version): Command {
         .option("--app-id <appId>", "AppID for the WeChat MP platform")
         .option("--server <url>", "Server URL to publish through (e.g. https://api.yourdomain.com)")
         .option("--api-key <apiKey>", "API key for the remote server")
-        .option("--env-file <file>", "Path to a .env file to load environment variables from</file>")
-        .option("--proxy <url>", "Proxy URL to use for requests</url>, ex: http://127.0.0.1:1080")
-        .action(async (inputContent: string | undefined, options: ClientPublishOptions) => {
+        .option("--env-file <file>", "Path to a .env file to load environment variables from")
+        .option("--proxy <url>", "Proxy URL to use for requests, ex: http://127.0.0.1:1080")
+        .action(async (inputContent: string | undefined, options: CLIPublishOptions) => {
             await runCommandWrapper(async () => {
-
-                 // 1. 读取环境变量
-                if(options.envFile){
-                    dotenv.config({ path: options.envFile });
+                // 读取环境变量文件（如果提供了 --env-file 选项）
+                if (options.envFile) {
+                    loadEnvFile(options.envFile);
                 }
 
+                // 设置代理（如果提供了 --proxy 选项）
+                await setupProxy(options.proxy);
 
                 // 如果传入了 --server，则走客户端（远程）模式
                 if (options.server) {
@@ -134,8 +141,13 @@ export function createProgram(version: string = pkg.version): Command {
         .description("Start a server to provide HTTP API for rendering and publishing")
         .option("-p, --port <port>", "Port to listen on (default: 3000)", "3000")
         .option("--api-key <apiKey>", "API key for authentication")
-        .action(async (options: { port?: string; apiKey?: string }) => {
+        .option("--env-file <file>", "Path to a .env file to load environment variables from")
+        .action(async (options: { port?: string; apiKey?: string; envFile?: string }) => {
             try {
+                // 读取环境变量文件（如果提供了 --env-file 选项）
+                if (options.envFile) {
+                    loadEnvFile(options.envFile);
+                }
                 const { serveCommand } = await import("./commands/serve.js");
                 const port = options.port ? parseInt(options.port, 10) : 3000;
                 await serveCommand({ port, version, apiKey: options.apiKey });
@@ -194,6 +206,22 @@ async function runCommandWrapper(action: () => Promise<void>) {
         }
         process.exit(1);
     }
+}
+
+async function setupProxy(proxyUrl?: string) {
+    const url = proxyUrl
+        || process.env.HTTPS_PROXY
+        || process.env.https_proxy
+        || process.env.HTTP_PROXY
+        || process.env.http_proxy
+        || process.env.ALL_PROXY;
+    if (!url) return;
+    const { ProxyAgent, setGlobalDispatcher, install } = await import("undici");
+    const cleanUrl = url.trim();
+    const agent = new ProxyAgent(cleanUrl);
+    setGlobalDispatcher(agent);
+    install();
+    console.error(`[Proxy] Global fetch proxy enabled: ${cleanUrl}`);
 }
 
 export const program = createProgram();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import { getInputContent } from "./utils.js";
 import path from "node:path";
 import input from "@inquirer/input";
 import password from "@inquirer/password";
-
+import dotenv from "dotenv";
 export function createProgram(version: string = pkg.version): Command {
     const program = new Command();
 
@@ -52,8 +52,17 @@ export function createProgram(version: string = pkg.version): Command {
         .option("--app-id <appId>", "AppID for the WeChat MP platform")
         .option("--server <url>", "Server URL to publish through (e.g. https://api.yourdomain.com)")
         .option("--api-key <apiKey>", "API key for the remote server")
+        .option("--env-file <file>", "Path to a .env file to load environment variables from</file>")
+        .option("--proxy <url>", "Proxy URL to use for requests</url>, ex: http://127.0.0.1:1080")
         .action(async (inputContent: string | undefined, options: ClientPublishOptions) => {
             await runCommandWrapper(async () => {
+
+                 // 1. 读取环境变量
+                if(options.envFile){
+                    dotenv.config({ path: options.envFile });
+                }
+
+
                 // 如果传入了 --server，则走客户端（远程）模式
                 if (options.server) {
                     options.clientVersion = version; // 将 CLI 版本传递给服务器，便于调试和兼容性处理


### PR DESCRIPTION
为 publish 命令添加 --proxy 参数，支持通过代理服务器进行微信 API 调用和
图片上传操作。支持 HTTP 代理协议，并提供
环境变量配置方式。

更新了文档说明，包括代理配置的使用方法和示例。