### PR TITLE
fix: add fallback for import.meta.main on Node.js < 22.18.0

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
 } from "@wenyan-md/core/wrapper";
 import { getInputContent } from "./utils.js";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import input from "@inquirer/input";
 import password from "@inquirer/password";
 import { loadEnvFile } from "node:process";
@@ -227,6 +228,17 @@ async function setupProxy(proxyUrl?: string) {
 export const program = createProgram();
 
 // 仅在作为主模块运行时执行 parse，防止测试文件 import 时意外触发
-if (import.meta.main) {
+// import.meta.main 在 Node.js >= 22.18.0 中可用，旧版本通过路径比较回退检测
+function isMainModule(): boolean {
+    if (import.meta.main !== undefined) return import.meta.main;
+    if (!process.argv[1]) return false;
+    try {
+        return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+    } catch {
+        return false;
+    }
+}
+
+if (isMainModule()) {
     program.parse(process.argv);
 }


### PR DESCRIPTION
## Summary

`import.meta.main` was introduced in Node.js v22.18.0. On older versions (e.g. v22.14.0), it is `undefined`, which causes the `if (import.meta.main)` guard to evaluate as falsy. As a result, `program.parse(process.argv)` is never called, and the CLI **silently exits with code 0** without executing any command or producing any output.

Since `package.json` does not specify an `engines` field, users on any Node.js version can install the CLI, and those on < 22.18.0 get a completely non-functional tool with no error message.

## Fix

Add `isMainModule()` helper that:
1. Uses `import.meta.main` when available (Node >= 22.18.0)
2. Falls back to comparing `import.meta.url` with `process.argv[1]` via `fileURLToPath` + `path.resolve`

## Testing

```bash
# Before fix (Node.js v22.14.0):
$ wenyan publish -f article.md -t claude --app-id ... --server ... --api-key ...
# (no output, exit 0 — nothing happens)

# After fix:
$ wenyan publish -f article.md -t claude --app-id ... --server ... --api-key ...
# 发布成功，Media ID: SFXRdRlyYGtK0V7lNuHCTFltzd9R5EtQFZ0l3xTAoylR0BOJxhZ4Kz6MMenRGloO
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)