### PR TITLE
feat: 支持 publish-image 命令（小绿书图文发布）

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { configDir } from "@wenyan-md/core/wrapper";
 import multer from "multer";
-import { publishToWechatDraft } from "@wenyan-md/core/wrapper";
+import { publishToWechatDraft, publishImageTextToWechatDraft } from "@wenyan-md/core/wrapper";
 
 export interface ServeOptions {
     port?: number;
@@ -140,20 +140,46 @@ export async function serveCommand(options: ServeOptions) {
             gzhContent.cover = resolveAssetPath(gzhContent.cover);
         }
 
-        const data = await publishToWechatDraft(
-            {
-                title: gzhContent.title,
-                content: gzhContent.content,
-                cover: gzhContent.cover,
-                author: gzhContent.author,
-                source_url: gzhContent.source_url,
-                need_open_comment: gzhContent.need_open_comment,
-                only_fans_can_comment: gzhContent.only_fans_can_comment,
-            },
-            {
-                appId: body.appId,
-            },
-        );
+        // 替换 image_list 中的 asset://
+        if (gzhContent.image_list && Array.isArray(gzhContent.image_list)) {
+            gzhContent.image_list = gzhContent.image_list.map((img: string) => {
+                if (img.startsWith("asset://")) return resolveAssetPath(img);
+                return img;
+            });
+        }
+
+        let data;
+        if (gzhContent.image_list && gzhContent.image_list.length > 0) {
+            // 图片文章（小绿书）
+            data = await publishImageTextToWechatDraft(
+                {
+                    title: gzhContent.title,
+                    content: gzhContent.content,
+                    images: gzhContent.image_list,
+                    cover: gzhContent.cover,
+                    author: gzhContent.author,
+                },
+                {
+                    appId: body.appId,
+                },
+            );
+        } else {
+            // 普通图文文章
+            data = await publishToWechatDraft(
+                {
+                    title: gzhContent.title,
+                    content: gzhContent.content,
+                    cover: gzhContent.cover,
+                    author: gzhContent.author,
+                    source_url: gzhContent.source_url,
+                    need_open_comment: gzhContent.need_open_comment,
+                    only_fans_can_comment: gzhContent.only_fans_can_comment,
+                },
+                {
+                    appId: body.appId,
+                },
+            );
+        }
 
         if (data.media_id) {
             res.json({


### PR DESCRIPTION
## Summary

- serve `/publish` 端点支持小绿书（image_list）发布
- 当上传的 JSON 包含 `image_list` 字段时，自动走 `publishImageTextToWechatDraft` 发布图片消息

## 背景

上游 wenyan-core 已在 `renderAndPublish` / `renderAndPublishToServer` 中内置了小绿书支持，通过 frontmatter 的 `image_list` 字段自动识别。CLI 本地模式无需额外改动。

本 PR 仅补充 server 模式下 `/publish` 端点对 `image_list` 的支持，使 server 模式也能正确发布小绿书。

## Usage

小绿书 markdown 文件：

```markdown
---
title: 周末西湖
cover: ./cover.jpg
author: 吉人
image_list:
  - ./photo1.jpg
  - ./photo2.jpg
  - ./photo3.jpg
---

周末去了趟西湖，天气很好。
```

```bash
# 本地模式（core 已支持，无需额外参数）
wenyan publish -f trip.md

# Server 模式（本 PR 使其支持小绿书）
wenyan publish -f trip.md --server https://api.example.com
```