### PR TITLE
fix(serve): 透传发布评论配置

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -147,6 +147,8 @@ export async function serveCommand(options: ServeOptions) {
                 cover: gzhContent.cover,
                 author: gzhContent.author,
                 source_url: gzhContent.source_url,
+                need_open_comment: gzhContent.need_open_comment,
+                only_fans_can_comment: gzhContent.only_fans_can_comment,
             },
             {
                 appId: body.appId,

--- a/tests/serve.test.ts
+++ b/tests/serve.test.ts
@@ -218,59 +218,110 @@ describe("serve.ts", () => {
     });
 
     describe("Publish Endpoint", () => {
-        // it("should accept valid JSON and proceed to publish flow", async () => {
-        //     mock.method(console, "log", () => {});
+        it("should forward comment options from uploaded json to publishToWechatDraft", async () => {
+            mock.method(console, "log", mock.fn());
 
-        //     // 模拟真实的 publishToWechatDraft，避免真调用微信
-        //     const core = await import("@wenyan-md/core/wrapper");
-        //     const mockPublish = mock.method(core, "publishToWechatDraft", async () => ({
-        //         media_id: "mock-media-id-123",
-        //     }));
+            const previousAppId = process.env.WECHAT_APP_ID;
+            const previousAppSecret = process.env.WECHAT_APP_SECRET;
+            process.env.WECHAT_APP_ID = "test-app-id";
+            process.env.WECHAT_APP_SECRET = "test-app-secret";
 
-        //     serverProcess = serveCommand({ port: testPort });
-        //     baseUrl = `http://localhost:${testPort}`;
-        //     await new Promise((resolve) => setTimeout(resolve, 200));
+            try {
+                const publishModule = await import("@wenyan-md/core/publish");
+                mock.method(publishModule.WechatPublisher.prototype, "getAccessTokenWithCache", async () => "mock-access-token");
+                mock.method(
+                    publishModule.WechatPublisher.prototype,
+                    "uploadImage",
+                    async () => ({
+                        media_id: "mock-upload-media-id",
+                        url: "https://mmbiz.qpic.cn/mock-uploaded-image",
+                    }),
+                );
+                const publishDraftMock = mock.method(
+                    publishModule.WechatPublisher.prototype,
+                    "publishToDraft",
+                    async () => ({ media_id: "mock-media-id-123" }),
+                );
 
-        //     // 1. 构造合法的文章 JSON
-        //     const articleJson = JSON.stringify({
-        //         title: "测试文章",
-        //         content: "<p>测试内容</p>",
-        //         author: "测试作者",
-        //         source_url: "https://example.com",
-        //     });
+                serverProcess = serveCommand({ port: testPort });
+                baseUrl = `http://localhost:${testPort}`;
+                await new Promise((resolve) => setTimeout(resolve, 200));
 
-        //     // 2. 上传这个 JSON 文件
-        //     const boundary = "----testupload";
-        //     const body = [
-        //         `--${boundary}`,
-        //         `Content-Disposition: form-data; name="file"; filename="article.json"`,
-        //         `Content-Type: application/json`,
-        //         ``,
-        //         articleJson,
-        //         `--${boundary}--`,
-        //     ].join("\r\n");
+                const imageBoundary = "----testimageupload";
+                const imageBody = [
+                    `--${imageBoundary}`,
+                    `Content-Disposition: form-data; name="file"; filename="cover.png"`,
+                    `Content-Type: image/png`,
+                    "",
+                    "fake-image-content",
+                    `--${imageBoundary}--`,
+                ].join("\r\n");
 
-        //     const uploadRes = await makeRequest("POST", "/upload", {
-        //         headers: {
-        //             "Content-Type": `multipart/form-data; boundary=${boundary}`,
-        //         },
-        //         body,
-        //     });
+                const imageUploadRes = await makeRequest("POST", "/upload", {
+                    headers: {
+                        "Content-Type": `multipart/form-data; boundary=${imageBoundary}`,
+                    },
+                    body: imageBody,
+                });
 
-        //     assert.equal(uploadRes.statusCode, 200);
-        //     const fileId = uploadRes.body.data.fileId;
+                assert.equal(imageUploadRes.statusCode, 200);
+                const imageFileId = imageUploadRes.body.data.fileId;
 
-        //     // 3. 调用发布接口
-        //     const publishRes = await makeRequest("POST", "/publish", {
-        //         headers: { "Content-Type": "application/json" },
-        //         body: JSON.stringify({ fileId }),
-        //     });
+                const articleJson = JSON.stringify({
+                    title: "测试文章",
+                    content: `<p>测试内容</p><img src="asset://${imageFileId}" />`,
+                    author: "测试作者",
+                    source_url: "https://example.com",
+                    need_open_comment: 1,
+                    only_fans_can_comment: 1,
+                });
 
-        //     // 4. 断言成功
-        //     assert.equal(publishRes.statusCode, 200);
-        //     assert.equal(publishRes.body.media_id, "mock-media-id-123");
-        //     assert.equal(mockPublish.mock.callCount(), 1);
-        // });
+                const articleBoundary = "----testarticleupload";
+                const articleBody = [
+                    `--${articleBoundary}`,
+                    `Content-Disposition: form-data; name="file"; filename="article.json"`,
+                    `Content-Type: application/json`,
+                    "",
+                    articleJson,
+                    `--${articleBoundary}--`,
+                ].join("\r\n");
+
+                const uploadRes = await makeRequest("POST", "/upload", {
+                    headers: {
+                        "Content-Type": `multipart/form-data; boundary=${articleBoundary}`,
+                    },
+                    body: articleBody,
+                });
+
+                assert.equal(uploadRes.statusCode, 200);
+                const fileId = uploadRes.body.data.fileId;
+
+                const publishRes = await makeRequest("POST", "/publish", {
+                    body: { fileId, appId: "test-app-id" },
+                });
+
+                assert.equal(publishRes.statusCode, 200);
+                assert.equal(publishRes.body.media_id, "mock-media-id-123");
+                assert.equal(publishDraftMock.mock.callCount(), 1);
+
+                const publishOptions = publishDraftMock.mock.calls[0].arguments[1];
+                assert.ok(publishOptions);
+                assert.equal(publishOptions.need_open_comment, 1);
+                assert.equal(publishOptions.only_fans_can_comment, 1);
+            } finally {
+                if (previousAppId === undefined) {
+                    delete process.env.WECHAT_APP_ID;
+                } else {
+                    process.env.WECHAT_APP_ID = previousAppId;
+                }
+
+                if (previousAppSecret === undefined) {
+                    delete process.env.WECHAT_APP_SECRET;
+                } else {
+                    process.env.WECHAT_APP_SECRET = previousAppSecret;
+                }
+            }
+        });
 
         it("should reject publish without fileId", async () => {
             mock.method(console, "log", mock.fn());


### PR DESCRIPTION
## Summary

- 在 `wenyan serve` 的 `/publish` 路径中，透传上传 JSON 内的 `need_open_comment` 和 `only_fans_can_comment`
- 为 `tests/serve.test.ts` 增加回归测试，覆盖评论配置在 server publish 流程中的透传行为
- 保持改动范围最小，仅修复 CLI server 这一层丢字段的问题

## Context

`wenyan-core` 中对评论配置的底层支持已经合并，但当前还未发布新的 tag / npm 版本。

这次 `wenyan-cli` PR 解决的是 server 侧 `/publish` 流程丢失评论参数的问题：
上传的 JSON 已经包含 `need_open_comment` / `only_fans_can_comment`，但 CLI 在调用发布链路前没有继续透传。

本地验证时使用了包含该改动的 `wenyan-core` 源码版本来确认完整链路。

## Test Plan

- [x] `pnpm test tests/serve.test.ts`
- [x] `pnpm typecheck`

## Notes

- 这次 PR 不引入新的 CLI 参数，也不扩展请求体验证逻辑
- 仅修复已有 server publish 路径中的参数丢失问题