### PR TITLE
fix(serve): 改善错误处理，避免打印完整堆栈跟踪

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -149,36 +149,40 @@ export async function serveCommand(options: ServeOptions) {
         }
 
         let data: WechatPublishResponse;
-        if (gzhContent.image_list && gzhContent.image_list.length > 0) {
-            // 图片文章（小绿书）
-            data = await publishImageTextToWechatDraft(
-                {
-                    title: gzhContent.title,
-                    content: gzhContent.content,
-                    images: gzhContent.image_list,
-                    cover: gzhContent.cover,
-                    author: gzhContent.author,
-                },
-                {
-                    appId: body.appId,
-                },
-            );
-        } else {
-            // 普通图文文章
-            data = await publishToWechatDraft(
-                {
-                    title: gzhContent.title,
-                    content: gzhContent.content,
-                    cover: gzhContent.cover,
-                    author: gzhContent.author,
-                    source_url: gzhContent.source_url,
-                    need_open_comment: gzhContent.need_open_comment,
-                    only_fans_can_comment: gzhContent.only_fans_can_comment,
-                },
-                {
-                    appId: body.appId,
-                },
-            );
+        try {
+            if (gzhContent.image_list && gzhContent.image_list.length > 0) {
+                // 图片文章（小绿书）
+                data = await publishImageTextToWechatDraft(
+                    {
+                        title: gzhContent.title,
+                        content: gzhContent.content,
+                        images: gzhContent.image_list,
+                        cover: gzhContent.cover,
+                        author: gzhContent.author,
+                    },
+                    {
+                        appId: body.appId,
+                    },
+                );
+            } else {
+                // 普通图文文章
+                data = await publishToWechatDraft(
+                    {
+                        title: gzhContent.title,
+                        content: gzhContent.content,
+                        cover: gzhContent.cover,
+                        author: gzhContent.author,
+                        source_url: gzhContent.source_url,
+                        need_open_comment: gzhContent.need_open_comment,
+                        only_fans_can_comment: gzhContent.only_fans_can_comment,
+                    },
+                    {
+                        appId: body.appId,
+                    },
+                );
+            }
+        } catch (err) {
+            throw wrapPublishError(err);
         }
 
         if (data.media_id) {
@@ -243,6 +247,27 @@ export async function serveCommand(options: ServeOptions) {
     });
 }
 
+/**
+ * 将 @wenyan-md/core 抛出的 Error 转换为用户友好的 AppError，
+ * 使其在 serve 模式下返回 400 而非 500，并改善错误提示。
+ */
+function wrapPublishError(err: unknown): AppError {
+    if (err instanceof AppError) return err;
+
+    const msg = err instanceof Error ? err.message : String(err);
+
+    // 路径无法解析（相对路径或跨平台路径在服务器上不存在）
+    if (msg.includes("InputPath must be an absolute path")) {
+        const pathMatch = msg.match(/'([^']+)'/);
+        const badPath = pathMatch ? pathMatch[1] : "";
+        return new AppError(
+            `无法解析图片路径 '${badPath}'。请确保图片已通过 /upload 接口上传（使用 asset:// 链接），或使用 http/https 网络图片。`,
+        );
+    }
+
+    return new AppError(msg);
+}
+
 function errorHandler(error: any, _req: Request, res: Response, next: NextFunction): void {
     if (res.headersSent) {
         return next(error);
@@ -256,7 +281,7 @@ function errorHandler(error: any, _req: Request, res: Response, next: NextFuncti
     const statusCode = isAppError || isMulterError ? 400 : 500;
 
     if (statusCode === 500) {
-        console.error("[Server Error]:", error);
+        console.error("[Server Error]:", message);
     }
 
     res.status(statusCode).json({


### PR DESCRIPTION
## Summary

- 用 try-catch 包裹 `publishToWechatDraft` / `publishImageTextToWechatDraft` 调用，将 `@wenyan-md/core` 抛出的 `Error` 转换为 `AppError`，使其在 serve 模式下返回 **400** 而非 **500**
- 路径解析失败时给出可操作的提示信息（建议使用 `asset://` 或 `http/https` 图片），而非原始的 `InputPath must be an absolute path`
- `errorHandler` 不再打印完整 `Error` 对象（含 stack trace），仅记录错误消息

## 问题背景

serve 模式下，当客户端发送了包含本地路径的图片（如 Windows 路径 `D:/Notes/...` 或相对路径 `../0.asset/...`）时，server 端会打印完整堆栈跟踪：

```
[Server Error]: Error: Invalid input: 'D:/Notes/0.asset/media/xxx.png'. InputPath must be an absolute path.
    at Object.resolveLocalPath (.../wrapper.js:88:17)
    at uploadImage (.../wrapper.js:425:37)
    ...
```

这些错误本质上是客户端输入问题，却被当作 500 服务端错误处理。

## 修复后的效果

1. **不再打印堆栈跟踪** — server 日志仅显示 `[Server Error]: <错误消息>`
2. **返回 400 而非 500** — core 抛出的输入校验错误被正确归类为客户端错误
3. **路径错误给出可操作建议** — 提示用户使用 `asset://` 链接或网络图片

## Test plan

- [ ] 启动 `wenyan serve`，发布一篇不含图片的文章 → 应返回 400 及友好提示
- [ ] 发布包含本地路径图片的文章 → 应返回 400 并提示使用 asset:// 或 http 图片
- [ ] 正常发布流程（上传图片 + 发布）→ 行为不变