### PR TITLE
docs: 补充小绿书（图片消息）相关文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,30 @@ source_url: http://
 
 ## 发布图片消息（小绿书）
 
-发布图片消息与发布图文消息唯一的区别在于`frontmatter`的一个参数`image_list`：
+发布图片消息与发布图文消息的区别在于 frontmatter 中需要指定图片列表。支持两种方式：
+
+### 方式一：使用 type: image（推荐）
+
+在 frontmatter 中设置 `type: image`，CLI 会自动从正文中提取所有图片：
 
 ```md
 ---
-title: 人勤春来早, 读书正当时
+title: 人勤春来早，读书正当时
+type: image
+---
+
+![](./1.jpeg)
+![](./2.jpeg)
+![](./3.jpeg)
+```
+
+### 方式二：手动指定 image_list
+
+直接在 frontmatter 中列出图片路径：
+
+```md
+---
+title: 人勤春来早，读书正当时
 image_list:
   - ./1.jpeg
   - ./2.jpeg
@@ -156,7 +175,7 @@ image_list:
 ---
 ```
 
-`image_list`最多20张，首张即为封面，
+`image_list` 最多 20 张，首张即为封面。
 
 ## Server 模式
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -4,17 +4,23 @@
 
 CLI 会自动处理图片上传、HTML 渲染和草稿创建，无需手动操作微信公众号后台。
 
+支持两种文章类型：
+
+- **图文文章**：以文字为主体的常规公众号文章
+- **图片消息（小绿书）**：以图片为主体的图集内容，在公众号中显示为小绿书样式
+
 ## 工作流程
 
 执行 `wenyan publish` 时，CLI 自动完成以下步骤：
 
 1. 读取 Markdown 内容（文件 / stdin / 直接输入）
 2. 解析 frontmatter（标题、封面等元数据）
-3. 自动检测正文和封面中的图片
-4. 上传图片到微信公众号素材库
-5. 将 Markdown 渲染为微信公众号兼容 HTML
-6. 创建公众号草稿
-7. 返回发布结果
+3. 如果设置 `type: image`，自动从正文提取图片路径
+4. 自动检测正文和封面中的图片
+5. 上传图片到微信公众号素材库
+6. 将 Markdown 渲染为微信公众号兼容 HTML（图文文章）/ 直接使用原始内容（小绿书）
+7. 创建公众号草稿
+8. 返回发布结果
 
 ## 内容输入方式
 
@@ -88,11 +94,63 @@ source_url: https://example.com
 | cover      | ❌  | 封面图片（本地路径或网络 URL） |
 | author     | ❌  | 作者                |
 | source_url | ❌  | 原文链接              |
+| type       | ❌  | 文章类型，设为 `image` 表示图片消息（小绿书） |
+| image_list | ❌  | 图片路径列表（小绿书专用，最多 20 张） |
 
 说明：
 
 * 如果未指定 cover，将自动使用正文第一张图片作为封面
 * cover 支持本地路径和网络 URL
+* `type` 和 `image_list` 用于图片消息发布，详见下方
+
+## 发布图片消息（小绿书）
+
+图片消息以图片为主体，适合发布图集类内容。支持两种方式：
+
+### 方式一：使用 type: image（推荐）
+
+在 frontmatter 中设置 `type: image`，CLI 会自动从正文中提取所有图片：
+
+```md
+---
+title: 人勤春来早，读书正当时
+type: image
+---
+
+![](./1.jpeg)
+![](./2.jpeg)
+![](./3.jpeg)
+![](./4.jpeg)
+![](./5.jpeg)
+```
+
+CLI 会自动：
+1. 提取正文中所有图片路径
+2. 将路径注入 `image_list`
+3. 从正文中移除图片引用
+
+### 方式二：手动指定 image_list
+
+直接在 frontmatter 中列出图片路径：
+
+```md
+---
+title: 人勤春来早，读书正当时
+image_list:
+  - ./1.jpeg
+  - ./2.jpeg
+  - ./3.jpeg
+  - ./4.jpeg
+  - ./5.jpeg
+---
+```
+
+### 说明
+
+* `image_list` 最多 20 张图片
+* 第一张图片自动作为封面（也可通过 `cover` 字段指定）
+* 图片消息不会应用主题样式，保持图片为主体
+* 支持本地路径和网络 URL
 
 ## 图片处理机制
 
@@ -138,6 +196,8 @@ wenyan publish \
 2. 上传到 Wenyan Server
 3. Server 调用微信公众号 API
 4. 返回发布结果
+
+Server 模式同样支持小绿书发布。CLI 会自动检测 `image_list`，将图片上传到 Server 并路由到图片消息发布接口。
 
 适用于：
 
@@ -234,6 +294,25 @@ wenyan publish \
   -f article.md \
   --no-mac-style \
   --no-footnote
+```
+
+### 发布图片消息（小绿书）
+
+```bash
+wenyan publish -f photos.md
+```
+
+其中 `photos.md` 内容：
+
+```md
+---
+title: 人勤春来早，读书正当时
+type: image
+---
+
+![](./1.jpeg)
+![](./2.jpeg)
+![](./3.jpeg)
 ```
 
 ### 使用远程 Server

--- a/docs/server.md
+++ b/docs/server.md
@@ -19,18 +19,24 @@ sequenceDiagram
 
     Note over Client: 用户/自动化程序触发发布指令
     Client->>Client: 解析 Markdown/提取图片/读取元数据
-    Client->>Server: POST /publish<br/>携带：Markdown 内容 + 图片文件 + 元数据 + API Key
+    Client->>Server: POST /upload (上传图片)
+    Server-->>Client: 返回 fileId (asset://)
+    Client->>Server: POST /upload (上传渲染后的 JSON)
+    Server-->>Client: 返回 fileId
+    Client->>Server: POST /publish (触发发布)
     Note over Server: 1. 验证 API Key 合法性
     Note over Server: 2. 处理图片资源（上传至微信素材库）
     Server->>Wechat: POST /media/upload (上传图片)
     Wechat-->>Server: 返回 media_id + 图片永久 URL
-    Note over Server: 3. 替换 Markdown 图片链接/渲染为微信兼容 HTML
+    Note over Server: 3. 替换图片链接/渲染 HTML
     Server->>Wechat: POST /draft/add (创建公众号草稿)
     Wechat-->>Server: 返回 draft_id (草稿箱 ID)
     Server-->>Client: 返回发布结果（success + draft_id / error 详情）
 ```
 
 文颜 Server 部署后暴露标准 HTTP 接口，支持 Wenyan CLI、Wenyan MCP 等客户端调用，适配自动化发布、批量发文、AI 生成后直接发布等场景。
+
+Server 同时支持 **图文文章** 和 **图片消息（小绿书）** 两种发布类型，客户端无需区分，Server 会根据内容自动路由。
 
 ## 快速部署
 
@@ -121,6 +127,25 @@ curl -X POST http://localhost:3000/publish \
     "macStyle": true
   }'
 ```
+
+### 小绿书（图片消息）Server 模式说明
+
+Server 模式完全支持图片消息（小绿书）发布。发布流程如下：
+
+**客户端处理：**
+
+1. 读取 Markdown 并解析 frontmatter
+2. 如果设置 `type: image`，自动从正文提取图片路径
+3. 将 `image_list` 中的本地图片通过 `/upload` 接口上传到 Server，路径替换为 `asset://fileId`
+4. 将渲染后的内容（JSON 格式）通过 `/upload` 接口上传
+
+**服务端处理：**
+
+1. 读取 JSON 内容，检测是否包含 `image_list`
+2. 替换 `image_list` 中的 `asset://` 路径为服务器本地路径
+3. 调用 `publishImageTextToWechatDraft` 发布图片消息到草稿箱
+
+客户端无需手动区分发布类型，CLI 会根据 `image_list` 是否存在自动选择发布路径。
 
 ## API 接口认证
 


### PR DESCRIPTION
## Summary

补充小绿书（图片消息）功能的相关文档，与之前合并的 PR #27 的代码变更对齐。

### 变更内容

- **docs/publish.md**: 新增「发布图片消息（小绿书）」章节，说明 `type: image`（推荐）和 `image_list` 两种方式；frontmatter 字段表补充 `type` 和 `image_list`；新增小绿书发布示例；工作流程补充图片提取步骤；Server 模式说明补充小绿书支持
- **docs/server.md**: 新增「小绿书 Server 模式说明」章节，说明客户端和服务端的图片消息处理流程；架构说明补充自动路由描述
- **README.md**: 「发布图片消息（小绿书）」章节补充 `type: image` 方式说明

## Test plan

- [ ] 检查文档内容与实际 CLI 行为一致
- [ ] 检查 Server 模式说明与 serve.ts 实现一致
- [ ] 检查 README frontmatter 示例格式正确