### PR TITLE
Forward WeChat cover crop fields from serve API

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -173,6 +173,8 @@ export async function serveCommand(options: ServeOptions) {
                         cover: gzhContent.cover,
                         author: gzhContent.author,
                         source_url: gzhContent.source_url,
+                        pic_crop_235_1: gzhContent.pic_crop_235_1,
+                        pic_crop_1_1: gzhContent.pic_crop_1_1,
                         need_open_comment: gzhContent.need_open_comment,
                         only_fans_can_comment: gzhContent.only_fans_can_comment,
                     },

--- a/tests/serve.test.ts
+++ b/tests/serve.test.ts
@@ -218,7 +218,7 @@ describe("serve.ts", () => {
     });
 
     describe("Publish Endpoint", () => {
-        it("should forward comment options from uploaded json to publishToWechatDraft", async () => {
+        it("should forward comment and crop options from uploaded json to publishToWechatDraft", async () => {
             mock.method(console, "log", mock.fn());
 
             const previousAppId = process.env.WECHAT_APP_ID;
@@ -272,6 +272,8 @@ describe("serve.ts", () => {
                     content: `<p>测试内容</p><img src="asset://${imageFileId}" />`,
                     author: "测试作者",
                     source_url: "https://example.com",
+                    pic_crop_235_1: "0_0_1_1",
+                    pic_crop_1_1: "0_0_0.425532_1",
                     need_open_comment: 1,
                     only_fans_can_comment: 1,
                 });
@@ -306,6 +308,8 @@ describe("serve.ts", () => {
 
                 const publishOptions = publishDraftMock.mock.calls[0].arguments[1];
                 assert.ok(publishOptions);
+                assert.equal(publishOptions.pic_crop_235_1, "0_0_1_1");
+                assert.equal(publishOptions.pic_crop_1_1, "0_0_0.425532_1");
                 assert.equal(publishOptions.need_open_comment, 1);
                 assert.equal(publishOptions.only_fans_can_comment, 1);
             } finally {


### PR DESCRIPTION
## Summary
- Forward `pic_crop_235_1` and `pic_crop_1_1` from uploaded article JSON to `publishToWechatDraft`.
- Extend the serve publish regression test to cover crop field forwarding.

## Dependency
- Depends on caol64/wenyan-core#32 being released in `@wenyan-md/core` before this can be merged as a ready PR.

## Test plan
- [x] pnpm typecheck with a local build of the core change
- [x] pnpm test with a local build of the core change
- [x] pnpm build with a local build of the core change